### PR TITLE
Fix profile loading error

### DIFF
--- a/src/main/kotlin/doublemoon/mahjongcraft/client/gui/icon/PlayerFaceIcon.kt
+++ b/src/main/kotlin/doublemoon/mahjongcraft/client/gui/icon/PlayerFaceIcon.kt
@@ -27,8 +27,10 @@ class PlayerFaceIcon(
 
     private fun loadGameProfileProperties() {
         coroutineScope.launch(Dispatchers.IO) {
-            val profile = SkullBlockEntity.fetchProfileByUuid(uuid).get().getOrNull()
-                ?: SkullBlockEntity.fetchProfileByName(name).get().getOrNull()
+            val profile = runCatching {
+                SkullBlockEntity.fetchProfileByUuid(uuid).join().orElse(null)
+                    ?: SkullBlockEntity.fetchProfileByName(name).join().orElse(null)
+            }.getOrNull()
             if (profile != null) gameProfile = profile
         }
     }

--- a/src/main/kotlin/doublemoon/mahjongcraft/game/mahjong/riichi/player/MahjongPlayerBase.kt
+++ b/src/main/kotlin/doublemoon/mahjongcraft/game/mahjong/riichi/player/MahjongPlayerBase.kt
@@ -564,7 +564,7 @@ abstract class MahjongPlayerBase : GamePlayer {
         tile: Tile, discards: List<Tile>,
         machi: List<Tile> = this.machi.map { it.mahjong4jTile },
     ): Boolean {
-        val discardedTiles = discardedTiles.map { it.mahjong4jTile }
+        val discardedTiles = this.discardedTiles.map { it.mahjong4jTile }
         if (tile in discardedTiles) return true //一般振聽
         //考慮同巡振聽
         val lastDiscard = discardedTiles.last() //玩家丟過的最後一張牌


### PR DESCRIPTION
## Summary
- handle exceptions when fetching `GameProfile` for player faces by using `runCatching` and `join()`
- fix furiten check by referencing `this.discardedTiles`

## Testing
- `./gradlew --stop`
- `./gradlew build -x test` *(fails: Waiting for lock)*
- `./gradlew test` *(fails: Waiting for lock)*

------
https://chatgpt.com/codex/tasks/task_e_684001a90da483249ee55c688f7b6e6b